### PR TITLE
account for when scala-library.jar is already loaded

### DIFF
--- a/scala-library-jars/lib/scala-library-jars.rb
+++ b/scala-library-jars/lib/scala-library-jars.rb
@@ -1,5 +1,11 @@
 # encoding: utf-8
 
 require 'java'
-
-Dir["#{File.expand_path('..', __FILE__)}/*.jar"].each { |jar| require(jar) }
+begin
+  v = Java::ScalaUtil::Properties.versionNumberString
+  if v !~ /^2\.10\./
+    raise LoadError, "Unexpected version of scala already loaded. Expected 2.10.x, got: #{v}"
+  end
+rescue NameError
+  Dir["#{File.expand_path('..', __FILE__)}/*.jar"].each { |jar| require(jar) }
+end


### PR DESCRIPTION
useful for projects which already include the scala jar via jbundler.